### PR TITLE
Front end error handling fixes.

### DIFF
--- a/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/TableSourceAddDeviceDevice.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/TableSourceAddDeviceDevice.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.Collections;
 using Hestia.backend;
 using Hestia.backend.models;
+using Hestia.backend.exceptions;
 
 namespace Hestia.DevicesScreen
 {
@@ -75,16 +76,16 @@ namespace Hestia.DevicesScreen
             {
                 try
                 {
-                 PluginInfo requiredInfo = 
-                        Globals.LocalServerInteractor.GetPluginInfo(collection, (string)this.plugins[indexPath.Row]);
+                    PluginInfo requiredInfo = 
+                    Globals.LocalServerInteractor.GetPluginInfo(collection, (string)this.plugins[indexPath.Row]);
                     
                     addDeviceProperties.pluginInfo = requiredInfo;
                     this.owner.NavigationController.PushViewController(addDeviceProperties, true);
                 }
-                catch (Exception e)
+                catch (ServerInteractionException ex)
                 {
                     Console.WriteLine("Exception while getting required info");
-                    Console.WriteLine(e.StackTrace);
+                    Console.WriteLine(ex.ToString());
                 }
             }
 

--- a/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/TableSourceAddDeviceDevice.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/TableSourceAddDeviceDevice.cs
@@ -7,8 +7,8 @@ using Hestia.DevicesScreen.resources;
 using System.Drawing;
 using System.Collections;
 using Hestia.backend;
-using Hestia.backend.models;
 using Hestia.backend.exceptions;
+using Hestia.backend.models;
 
 namespace Hestia.DevicesScreen
 {

--- a/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDevice.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDevice.cs
@@ -7,8 +7,8 @@ using Hestia.DevicesScreen.resources;
 using System.Drawing;
 using System.Collections;
 using Hestia.backend;
-using Hestia.backend.models;
 using Hestia.backend.exceptions;
+using Hestia.backend.models;
 
 namespace Hestia
 {

--- a/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDevice.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDevice.cs
@@ -8,7 +8,7 @@ using System.Drawing;
 using System.Collections;
 using Hestia.backend;
 using Hestia.backend.models;
-
+using Hestia.backend.exceptions;
 
 namespace Hestia
 {
@@ -19,6 +19,7 @@ namespace Hestia
 
         // List of manufacturers
         List<string> collections;
+        
         // Stores list of plugins per manufacturer
         Hashtable collection_plugins;
 
@@ -46,11 +47,12 @@ namespace Hestia
                 }
      
             }
-            catch (Exception e)
+            catch (ServerInteractionException ex)
             {
                 Console.WriteLine("Exception while using serverInteractor");
-                Console.WriteLine(e.StackTrace);
+                Console.WriteLine(ex.ToString());
             }
+            
             // Contains methods that describe behavior of table
             table.Source = new TableSourceAddDeviceManufacturer(collections, collection_plugins, this);
 

--- a/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDeviceProperties.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDeviceProperties.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using UIKit;
+using Hestia.backend.exceptions;
 using Hestia.backend.models;
 using Hestia.DevicesScreen;
 using Hestia.DevicesScreen.AddDeviceScreen;
@@ -54,10 +55,10 @@ namespace Hestia
                 {
                     Globals.LocalServerInteractor.AddDevice(pluginInfo);
                 }
-                catch (Exception except)
+                catch (ServerInteractionException ex)
                 {
                     Console.WriteLine("Exception while adding device to server");
-                    Console.WriteLine(except.StackTrace);
+                    Console.WriteLine(ex.ToString());
                 }
 
                 // Get the root view contoller and cancel the editing state

--- a/Hestia/Hestia/frontend/DevicesScreen/TableSourceDevicesMain.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/TableSourceDevicesMain.cs
@@ -7,9 +7,9 @@ using Hestia.DevicesScreen.resources;
 using System.Drawing;
 using System.Collections;
 using Hestia.backend;
+using Hestia.backend.exceptions;
 using Hestia.backend.models;
 using Hestia.DevicesScreen.EditDevice;
-
 
 namespace Hestia.DevicesScreen
 {
@@ -110,9 +110,10 @@ namespace Hestia.DevicesScreen
                         // remove device from server 
                         Globals.LocalServerInteractor.RemoveDevice(TableItems[indexPath.Row]);
                     }
-                    catch(Exception e)
+                    catch(ServerInteractionException ex)
                     {
-                        Console.Out.WriteLine(e.StackTrace);
+                        Console.WriteLine("Exception while removing device");
+                        Console.Out.WriteLine(ex.ToString());
                     }
                     TableItems.RemoveAt(indexPath.Row);
                     // delete the row from the table

--- a/Hestia/Hestia/frontend/DevicesScreen/UITableViewControllerDevicesMain.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/UITableViewControllerDevicesMain.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Collections;
 
 using Hestia.DevicesScreen.resources;
-using Hestia.backend;
+using Hestia.backend.exceptions;
 using Hestia.backend.models;
 
 namespace Hestia.DevicesScreen
@@ -50,10 +50,10 @@ namespace Hestia.DevicesScreen
             {
                 devices = Globals.getDevices();
             }
-            catch (Exception e)
+            catch (ServerInteractionException ex)
             {
                 Console.Out.WriteLine("Exception while getting devices from server");
-                Console.Out.WriteLine(e.StackTrace);
+                Console.Out.WriteLine(ex.ToString());
             }
             table.Source = new TableSource(devices, this); 
         }


### PR DESCRIPTION
This replaces the default Exception for the new ServerInteractionException. When a exception occurs, instead of only the stacktrace, all relevant info is now printed: https://stackoverflow.com/questions/4450604/pretty-printing-exceptions-in-c-sharp