### PR TITLE
Set minimum required IOS version to 9.0

### DIFF
--- a/Hestia/Hestia/Hestia.csproj
+++ b/Hestia/Hestia/Hestia.csproj
@@ -173,17 +173,39 @@
     <Folder Include="Assets.xcassets\LogoLaunchscreen.imageset\" />
   </ItemGroup>
   <ItemGroup>
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie120.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie80kopie.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie87.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie60kopie.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie40kopie.png" />
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie1024kopie.png" />
-    <ImageAsset Include="Assets.xcassets\LogoLaunchscreen.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\LogoLaunchscreen.imageset\hestialogo_white.png" />
-    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie120.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie80kopie.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie87.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie60kopie.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie40kopie.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\appiconkopie1024kopie.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LogoLaunchscreen.imageset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LogoLaunchscreen.imageset\hestialogo_white.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\LaunchImage.launchimage\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
   </ItemGroup>
   <ItemGroup>
     <ITunesArtwork Include="iTunesArtwork" />

--- a/Hestia/Hestia/Info.plist
+++ b/Hestia/Hestia/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>10.3</string>
+	<string>9.0</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Usage Description</string>
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
I've tested the app on IOS 9.0 and 10.3, on both versions the app ran perfectly fine, therefore I've set the minimum required version to 9.0. Only 0.84% of all ios devices run IOS 8 or below, that's why I've excluded those operating systems. Source: https://data.apteligent.com/ios/
btw I don't know why visual studio changed the Hestia.csproj file, but I think it doesn't matter.