### PR TITLE
Fixed bug in Globals.cs.

### DIFF
--- a/Hestia/Hestia/frontend/DevicesScreen/TableSourceDevicesMain.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/TableSourceDevicesMain.cs
@@ -202,7 +202,7 @@ namespace Hestia.DevicesScreen
             List<backend.models.Activator> temp_activator = new List<backend.models.Activator>();
 
 
-            TableItems.Add(new Device(" ", "New Device ", " ", temp_activator, Globals.getTemporyNetworkHandler()));
+            TableItems.Add(new Device(" ", "New Device ", " ", temp_activator, Globals.GetTemporyNetworkHandler()));
 
             tableView.EndUpdates(); // applies the changes
         }

--- a/Hestia/Hestia/frontend/resources/Globals.cs
+++ b/Hestia/Hestia/frontend/resources/Globals.cs
@@ -36,7 +36,7 @@ namespace Hestia.DevicesScreen.resources
             return devices;
         }
 
-        public static NetworkHandler getTemporyNetworkHandler()
+        public static NetworkHandler GetTemporyNetworkHandler()
         {
             NetworkHandler temp_networkhandler;
             if(LocalLogin)
@@ -45,10 +45,9 @@ namespace Hestia.DevicesScreen.resources
             }
             else
             {
-                temp_networkhandler = new NetworkHandler(FirebaseServers[0].Interactor.GetNetworkHandler().Ip, FirebaseServers[0].Interactor.GetNetworkHandler().Port);
+                temp_networkhandler = new NetworkHandler(FirebaseServers[0].Interactor.NetworkHandler.Ip, FirebaseServers[0].Interactor.NetworkHandler.Port);
             }
             return temp_networkhandler;
         }
-    
     }
 }


### PR DESCRIPTION
There does not exists a `GetNetworkHandler()` method in `ServerInteractor.cs`. The property `NetworkHandler` should be used instead. This was causing build errors.