### PR TITLE
Make it possible to change device name/activator state on remote servers

### DIFF
--- a/Hestia/Hestia/backend/HestiaServerInteractor.cs
+++ b/Hestia/Hestia/backend/HestiaServerInteractor.cs
@@ -57,7 +57,7 @@ namespace Hestia.backend
             }
 
             DeviceDeserializer deserializer = new DeviceDeserializer();
-            var devices = deserializer.DeserializeDevices(responsePayload, networkHandler);
+            var devices = deserializer.DeserializeDevices(responsePayload, this);
 
             return devices;
         }
@@ -84,6 +84,30 @@ namespace Hestia.backend
             }
         }
 
+        public void ChangeDeviceName(Device device, string name)
+        {
+            string endpoint = strings.devicePath + device.DeviceId;
+            JObject nameJson = new JObject
+            {
+                ["name"] = name
+            };
+
+            if (isRemoteServer)
+            {
+                JObject requestPayload = new JObject
+                {
+                    { "requestType", "PUT" },
+                    { "endpoint", '/' + endpoint },
+                    { "optionalPayload", nameJson }
+                };
+                networkHandler.Post(requestPayload, hestiaWebEndpoint);
+            }
+            else
+            {
+                networkHandler.Put(nameJson, endpoint);
+            }
+        }
+
         public void RemoveDevice(Device device)
         {
             string endpoint = strings.devicePath + device.DeviceId;
@@ -101,6 +125,30 @@ namespace Hestia.backend
             else
             {
                 networkHandler.Delete(endpoint);
+            }
+        }
+
+        public void SetActivatorState(Activator activator, ActivatorState activatorState)
+        {
+            string endpoint = strings.devicePath + activator.Device.DeviceId + "/" + strings.activatorsPath + activator.ActivatorId;
+            JObject activatorStateJson = new JObject
+            {
+                ["state"] = new JValue(activatorState.RawState)
+            };
+
+            if (isRemoteServer)
+            {
+                JObject requestPayload = new JObject
+                {
+                    { "requestType", "POST" },
+                    { "endpoint", '/' + endpoint },
+                    { "optionalPayload", activatorStateJson }
+                };
+                networkHandler.Post(requestPayload, hestiaWebEndpoint);
+            }
+            else
+            {
+                networkHandler.Post(activatorStateJson, endpoint);
             }
         }
 

--- a/Hestia/Hestia/backend/NetworkHandler.cs
+++ b/Hestia/Hestia/backend/NetworkHandler.cs
@@ -14,7 +14,7 @@ namespace Hestia.backend
         private int port;
         private bool hasPort;
         private RestClient client;
-        private bool usesAuth0;
+        private bool usesAuth;
         private string accessToken; // auth0 access token
 
         public string Ip
@@ -35,9 +35,9 @@ namespace Hestia.backend
                 SetRestClient();
             }
         }
-        public bool UsesAuth0
+        public bool UsesAuth
         {
-            get => usesAuth0;
+            get => usesAuth;
         }
         public bool HasPort
         {
@@ -48,7 +48,7 @@ namespace Hestia.backend
         {
             this.ip = ip;
             this.hasPort = false;
-            this.usesAuth0 = false;
+            this.usesAuth = false;
 
             SetRestClient();
             TrustAllCerts();
@@ -59,7 +59,7 @@ namespace Hestia.backend
             this.ip = ip;
             this.port = port;
             this.hasPort = true;
-            this.usesAuth0 = false;
+            this.usesAuth = false;
 
             SetRestClient();
             TrustAllCerts();
@@ -69,7 +69,7 @@ namespace Hestia.backend
         {
             this.ip = ip;
             this.hasPort = false;
-            this.usesAuth0 = true;
+            this.usesAuth = true;
             this.accessToken = accessToken;
 
             SetRestClient();
@@ -81,7 +81,7 @@ namespace Hestia.backend
             this.ip = ip;
             this.port = port;
             this.hasPort = true;
-            this.usesAuth0 = true;
+            this.usesAuth = true;
             this.accessToken = accessToken;
 
             SetRestClient();
@@ -131,7 +131,7 @@ namespace Hestia.backend
         {
             request.Timeout = Int32.Parse(strings.requestTimeout);
 
-            if (usesAuth0)
+            if (usesAuth)
             {
                 request.AddParameter("Authorization", string.Format("Bearer " + accessToken), ParameterType.HttpHeader);
             }

--- a/Hestia/Hestia/backend/models/Activator.cs
+++ b/Hestia/Hestia/backend/models/Activator.cs
@@ -1,7 +1,4 @@
-﻿using Hestia.Resources;
-using Newtonsoft.Json.Linq;
-using System;
-
+﻿
 namespace Hestia.backend.models
 {
     public class Activator
@@ -33,14 +30,7 @@ namespace Hestia.backend.models
             set
             {
                 state = value;
-
-                string endpoint = strings.devicePath + device.DeviceId + "/" + strings.activatorsPath + activatorId;
-                JObject activatorState = new JObject
-                {
-                    ["state"] = new JValue(state.RawState)
-                };
-
-                Device.NetworkHandler.Post(activatorState, endpoint);
+                device.ServerInteractor.SetActivatorState(this, state);
             }
         }
         public Device Device
@@ -57,30 +47,9 @@ namespace Hestia.backend.models
             this.state = state;
         }
 
-        new
-        public Boolean Equals(Object obj)
+        public override string ToString()
         {
-            if (!(obj is Activator))
-            {
-                return false;
-            }
-            Activator activator = (Activator)obj;
-            return (this == activator || (this.ActivatorId.Equals(activator.ActivatorId) &&
-                rank.Equals(activator.Rank) &&
-                state.Equals(activator.State) &&
-                name.Equals(activator.Name)));
-        }
-
-        new
-        public Exception GetHashCode()
-        {
-            return new NotImplementedException();
-        }
-
-        new
-        public String ToString()
-        {
-            return this.name + " " + this.state;
+            return name + " " + state;
         }
     }
 }

--- a/Hestia/Hestia/backend/models/Device.cs
+++ b/Hestia/Hestia/backend/models/Device.cs
@@ -1,6 +1,4 @@
-﻿using Hestia.Resources;
-using Newtonsoft.Json.Linq;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace Hestia.backend.models
@@ -11,7 +9,7 @@ namespace Hestia.backend.models
         private string name;
         private string type;
         private List<Activator> activators;
-        private NetworkHandler networkHandler;
+        private HestiaServerInteractor serverInteractor;
 
         public string DeviceId
         {
@@ -24,14 +22,7 @@ namespace Hestia.backend.models
             set
             {
                 name = value;
-
-                string endpoint = strings.devicePath + deviceId;
-                JObject deviceName = new JObject
-                {
-                    ["name"] = name
-                };
-
-                networkHandler.Put(deviceName, endpoint);
+                serverInteractor.ChangeDeviceName(this, name);
             }
         }
         public string Type
@@ -44,49 +35,24 @@ namespace Hestia.backend.models
             get => activators;
             set => activators = value;
         }
-        public NetworkHandler NetworkHandler
+        public HestiaServerInteractor ServerInteractor
         {
-            get => networkHandler;
-            set => networkHandler = value;
+            get => serverInteractor;
+            set => serverInteractor = value;
         }
         
-        public Device(string deviceId, string name, string type, List<Activator> activators, NetworkHandler networkHandler)
+        public Device(string deviceId, string name, string type, List<Activator> activators, HestiaServerInteractor serverInteractor)
         {
             this.deviceId = deviceId;
             this.name = name;
             this.type = type;
             this.activators = activators;
-            this.networkHandler = networkHandler;
+            this.serverInteractor = serverInteractor;
         }
 
-        new
-        public Boolean Equals(Object obj)
+        public override string ToString()
         {
-            if (!(obj is Device)) return false;
-            Device device = (Device)obj;
-            return (this == device || (this.DeviceId.Equals(device.DeviceId) &&
-                    Name.Equals(device.Name) &&
-                    Type.Equals(device.Type) &&
-                    Activators.Equals(device.Activators) &&
-                    NetworkHandler.Equals(device.NetworkHandler)));
-        }
-
-        new
-        public int GetHashCode()
-        {
-            int multiplier = int.Parse(Resources.strings.hashCodeMultiplier);
-            int result = DeviceId.GetHashCode();
-            result = result * multiplier + Name.GetHashCode();
-            result = result * multiplier + GetType().GetHashCode();
-            result = result * multiplier + Activators.GetHashCode();
-            result = result * multiplier + NetworkHandler.GetHashCode();
-            return result;
-        }
-
-        new
-        public String ToString()
-        {
-            return name + " " + deviceId + " " + activators + "\n";
+            return name + " " + deviceId;
         }
     }
 }

--- a/Hestia/Hestia/backend/models/deserializers/DeviceDeserializer.cs
+++ b/Hestia/Hestia/backend/models/deserializers/DeviceDeserializer.cs
@@ -9,7 +9,7 @@ namespace Hestia.backend.models.deserializers
     public class DeviceDeserializer
     {
         // deserialize a single device from a JToken
-        public Device DeserializeDevice(JToken jT, NetworkHandler networkHandler)
+        public Device DeserializeDevice(JToken jT, HestiaServerInteractor serverInteractor)
         {
             // get id, name and type
             string id = jT.Value<string>("deviceId");
@@ -26,7 +26,7 @@ namespace Hestia.backend.models.deserializers
                 activatorList.Add(activatorDeserializer.DeserializeActivator(activator));
             }
 
-            Device device = new Device(id, name, type, activatorList, networkHandler);
+            Device device = new Device(id, name, type, activatorList, serverInteractor);
 
             foreach(Activator activator in activatorList)
             {
@@ -38,13 +38,13 @@ namespace Hestia.backend.models.deserializers
 
         // Use this function if you want to deserialize multiple devices.
         // Useful when you get all the devices from the server and want to deserialize them into a list of devices.
-        public List<Device> DeserializeDevices(JToken devices, NetworkHandler networkHandler)
+        public List<Device> DeserializeDevices(JToken devices, HestiaServerInteractor serverInteractor)
         {
             List<Device> deviceList = new List<Device>();
             
             foreach(JToken device in devices)
             {
-                deviceList.Add(DeserializeDevice(device, networkHandler));
+                deviceList.Add(DeserializeDevice(device, serverInteractor));
             }
 
             return deviceList;


### PR DESCRIPTION
I've replaced the networkhandler in `Device.cs` for a server interactor. This is done because the device needs to know the server id (in case of a remote server) for changing its name. I've not updated the front end code, because I'm not familiar enought with the front end code. Marc can update it. So the app doesn't build currently. Also quite a few unit tests are rekt, I will repair them in the next sprint (and add new ones).