### PR TITLE
Feature/development/headers devices main

### DIFF
--- a/Hestia/Hestia/frontend/DevicesScreen/TableSourceDevicesMain.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/TableSourceDevicesMain.cs
@@ -258,12 +258,11 @@ namespace Hestia.DevicesScreen
 		{
             if(Globals.LocalLogin)
             {
-                return Globals.LocalServerinteractor.ToString();
+                return Globals.ServerName + " " + Globals.IP + ":" + Globals.Port;
             }
-            else
-            {
-                return Globals.GetSelectedServers()[(int)section].ToString();
-            }
+
+            HestiaServer server = Globals.GetSelectedServers()[(int)section];
+            return server.Name;
         }
    	}
 }

--- a/Hestia/Hestia/frontend/DevicesScreen/UITableViewControllerDevicesMain.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/UITableViewControllerDevicesMain.cs
@@ -50,7 +50,7 @@ namespace Hestia.DevicesScreen
             else
             {
                 source.numberOfServers = Globals.GetNumberOfSelectedServers();
-                foreach (HestiaServerInteractor interactor in Globals.GetSelectedServers())
+                foreach (HestiaServerInteractor interactor in Globals.GetInteractorsOfSelectedServers())
                 {
                     try
                     {

--- a/Hestia/Hestia/frontend/Firebase/ServerSelectScreen/UITableViewServerList.cs
+++ b/Hestia/Hestia/frontend/Firebase/ServerSelectScreen/UITableViewServerList.cs
@@ -42,7 +42,7 @@ namespace Hestia
 
         bool ShouldPerformSegue()
         {
-            foreach (HestiaServerInteractor interactor in Globals.GetSelectedServers())
+            foreach (HestiaServerInteractor interactor in Globals.GetInteractorsOfSelectedServers())
             {
                 try
                 {

--- a/Hestia/Hestia/frontend/Firebase/TableSourceAddDeviceChooseServer.cs
+++ b/Hestia/Hestia/frontend/Firebase/TableSourceAddDeviceChooseServer.cs
@@ -38,7 +38,7 @@ namespace Hestia
                 cell = new UITableViewCell(UITableViewCellStyle.Default, Resources.strings.addDeviceChooseServerCell);
             }
 
-            cell.TextLabel.Text = Globals.GetSelectedServers()[indexPath.Row].ToString();
+            cell.TextLabel.Text = Globals.GetInteractorsOfSelectedServers()[indexPath.Row].ToString();
 
             return cell;
         }
@@ -46,7 +46,7 @@ namespace Hestia
         // Pushes the properties window
         public override void RowSelected(UITableView tableView, NSIndexPath indexPath)
         { 
-            Globals.ServerToAddDeviceTo = Globals.GetSelectedServers()[indexPath.Row];
+            Globals.ServerToAddDeviceTo = Globals.GetInteractorsOfSelectedServers()[indexPath.Row];
             UITableViewControllerAddDevice addDevice =
                 this.owner.Storyboard.InstantiateViewController("AddManufacturer")
                     as UITableViewControllerAddDevice;

--- a/Hestia/Hestia/frontend/resources/Globals.cs
+++ b/Hestia/Hestia/frontend/resources/Globals.cs
@@ -32,7 +32,7 @@ namespace Hestia.DevicesScreen.resources
         public static HestiaServerInteractor ServerToAddDeviceTo { get; set; }
         public static List<HestiaServer> Auth0Servers { get; set; }
 
-        public static List<HestiaServerInteractor> GetSelectedServers()
+        public static List<HestiaServerInteractor> GetInteractorsOfSelectedServers()
         {
             List<HestiaServerInteractor> serverInteractors = new List<HestiaServerInteractor>();
             foreach(HestiaServer auth0server in Auth0Servers)
@@ -45,9 +45,22 @@ namespace Hestia.DevicesScreen.resources
             return serverInteractors;
         }
 
+        public static List<HestiaServer> GetSelectedServers()
+        {
+            List<HestiaServer> servers = new List<HestiaServer>();
+            foreach (HestiaServer auth0server in Auth0Servers)
+            {
+                if (auth0server.Selected)
+                {
+                    servers.Add(auth0server);
+                }
+            }
+            return servers;
+        }
+
         public static nint GetNumberOfSelectedServers()
         {
-            return GetSelectedServers().Count;
+            return GetInteractorsOfSelectedServers().Count;
         }
 
         // Get devices for only local servers or selected Firebase Servers
@@ -60,7 +73,7 @@ namespace Hestia.DevicesScreen.resources
             }
             else
             {
-                foreach (HestiaServerInteractor server in GetSelectedServers())
+                foreach (HestiaServerInteractor server in GetInteractorsOfSelectedServers())
                 {
                     devices.AddRange(server.GetDevices());
                 }


### PR DESCRIPTION
Display the Servername + IP:Port in the header in case of local login. Display Name in case of global login, because IP and Port are not reachable, they are not in the HestiaServer object and the HestiaServerInteractor has the IP of the Webserver. If you think it is nice to display this information in the header, can you add this to the back end @daangroot ?