### PR TITLE
Better printing of exceptions.

### DIFF
--- a/Hestia/Hestia/AppDelegate.cs
+++ b/Hestia/Hestia/AppDelegate.cs
@@ -41,9 +41,9 @@ namespace Hestia
                 string address = strings.defaultPrefix + defaultIP + ":" + int.Parse(strings.defaultPort);
                 bool validIp = PingServer.Check(address);
             }
-            catch (Exception exception)
+            catch (Exception ex)
             {
-                Console.WriteLine(exception.StackTrace);
+                Console.WriteLine(ex.ToString());
                 return false;
             }
             return true;
@@ -68,7 +68,7 @@ namespace Hestia
             catch (ServerInteractionException ex)
             {
                 Console.WriteLine("Exception while posting user. User possibly already exists.");
-                Console.WriteLine(ex.StackTrace);
+                Console.WriteLine(ex.ToString());
             }
             Globals.Auth0Servers = new System.Collections.Generic.List<backend.models.HestiaServer>();
             try
@@ -78,7 +78,7 @@ namespace Hestia
             catch(ServerInteractionException ex)
             {
                 Console.WriteLine("Exception while getting servers");
-                Console.WriteLine(ex.StackTrace);
+                Console.WriteLine(ex.ToString());
                 WarningMessage.Display("Exception while getting servers", "Could not get local server list from webserver", Window.RootViewController);
             }
         }

--- a/Hestia/Hestia/Hestia.csproj
+++ b/Hestia/Hestia/Hestia.csproj
@@ -306,10 +306,18 @@
     <ImageAsset Include="Assets.xcassets\VoiceControlIconInverted.imageset\microphone_icon_inverted_150.png">
       <Visible>false</Visible>
     </ImageAsset>
-    <ImageAsset Include="Assets.xcassets\VoiceControlIcon2.imageset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\VoiceControlIcon2.imageset\microphone_icon_inverted_50.png" />
-    <ImageAsset Include="Assets.xcassets\VoiceControlIcon2.imageset\microphone_icon_inverted_100.png" />
-    <ImageAsset Include="Assets.xcassets\VoiceControlIcon2.imageset\microphone_icon_inverted_150.png" />
+    <ImageAsset Include="Assets.xcassets\VoiceControlIcon2.imageset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\VoiceControlIcon2.imageset\microphone_icon_inverted_50.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\VoiceControlIcon2.imageset\microphone_icon_inverted_100.png">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\VoiceControlIcon2.imageset\microphone_icon_inverted_150.png">
+      <Visible>false</Visible>
+    </ImageAsset>
   </ItemGroup>
   <ItemGroup>
     <ITunesArtwork Include="iTunesArtwork" />

--- a/Hestia/Hestia/backend/utils/JsonValidator.cs
+++ b/Hestia/Hestia/backend/utils/JsonValidator.cs
@@ -29,7 +29,7 @@ namespace Hestia.backend
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine(ex);
+                    Console.WriteLine(ex.ToString());
                     return false;
                 }
             }

--- a/Hestia/Hestia/backend/utils/PingServer.cs
+++ b/Hestia/Hestia/backend/utils/PingServer.cs
@@ -13,9 +13,10 @@ namespace Hestia.backend.utils
                 interactor.GetDevices();
                 return true;
             }
-            catch (ServerInteractionException)
+            catch (ServerInteractionException ex)
             {
-                Console.Out.Write("No such server exists");
+                Console.WriteLine("No such server exists");
+                Console.WriteLine(ex.ToString());
                 return false;
             }
         }

--- a/Hestia/Hestia/frontend/Auth0/ServerSelectScreen/ViewControllerServerList.cs
+++ b/Hestia/Hestia/frontend/Auth0/ServerSelectScreen/ViewControllerServerList.cs
@@ -80,7 +80,7 @@ namespace Hestia
                 catch (ServerInteractionException ex)
                 {
                     Console.WriteLine("Exception while getting devices from local server");
-                    Console.WriteLine(ex);
+                    Console.WriteLine(ex.ToString());
                     WarningMessage.Display("Could not fetch devices", "The server information is invalid. Did you forget to include https://?", this);
                     return false;
                 }

--- a/Hestia/Hestia/frontend/DevicesScreen/ActivatorScreen/TableSourceActivators.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/ActivatorScreen/TableSourceActivators.cs
@@ -51,7 +51,7 @@ namespace Hestia.DevicesScreen.ActivatorScreen
                     catch(ServerInteractionException ex) 
                     {
                         Console.WriteLine("Exception while changing activator state");
-                        Console.WriteLine(ex);
+                        Console.WriteLine(ex.ToString());
                         WarningMessage.Display("Could not set activator", "An exception occurred when changing the state of the activator on the server", owner);
 
                         // Reset back the switch
@@ -80,7 +80,7 @@ namespace Hestia.DevicesScreen.ActivatorScreen
                     catch(ServerInteractionException ex)
                     {
                         Console.WriteLine("Exception while changing activator state");
-                        Console.WriteLine(ex);
+                        Console.WriteLine(ex.ToString());
                         WarningMessage.Display("Could not set activator", "An exception occurred when changing the state of the activator on the server", owner);
 
                         // Reset back the slider

--- a/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/TableSourceAddDeviceDevice.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/TableSourceAddDeviceDevice.cs
@@ -75,7 +75,7 @@ namespace Hestia.DevicesScreen
                 catch (ServerInteractionException ex)
                 {
                     Console.WriteLine("Exception while getting required info");
-                    Console.WriteLine(ex);
+                    Console.WriteLine(ex.ToString());
                     WarningMessage.Display("Exception", "An exception occured on the server trying to get information for available plugins", owner);
                 }
             }

--- a/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDevice.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDevice.cs
@@ -41,7 +41,7 @@ namespace Hestia
             catch (ServerInteractionException ex)
             {
                 Console.WriteLine("Exception while using serverInteractor");
-                Console.WriteLine(ex);
+                Console.WriteLine(ex.ToString());
                 WarningMessage.Display("Exception", "An exception occured on the server trying to get available plugins", this);
             }
             

--- a/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDeviceProperties.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/AddDeviceScreen/UITableViewControllerAddDeviceProperties.cs
@@ -106,7 +106,7 @@ namespace Hestia
             catch (ServerInteractionException ex)
             {
                 Console.WriteLine("Exception while adding device to server");
-                Console.WriteLine(ex);
+                Console.WriteLine(ex.ToString());
                 WarningMessage.Display("Exception", "Could not add device", this);
             }
         }

--- a/Hestia/Hestia/frontend/DevicesScreen/EditDevice/UIViewControllerEditDeviceName.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/EditDevice/UIViewControllerEditDeviceName.cs
@@ -66,7 +66,7 @@ namespace Hestia.DevicesScreen.EditDevice
                     catch (ServerInteractionException ex)
                     {
                         Console.WriteLine("Exception while changing device name");
-                        Console.WriteLine(ex);
+                        Console.WriteLine(ex.ToString());
                         WarningMessage.Display("Exception", "An exception occurred on the server when changing the name of the device", this);  
                     } 
                 }

--- a/Hestia/Hestia/frontend/DevicesScreen/TableSourceDevicesMain.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/TableSourceDevicesMain.cs
@@ -149,7 +149,7 @@ namespace Hestia.DevicesScreen
                 catch (ServerInteractionException ex)
                 {
                     Console.WriteLine("Exception while removing device. (Bug in server: exception is always thrown)");
-                    Console.Out.WriteLine(ex);
+                    Console.Out.WriteLine(ex.ToString());
                 }
             }
             else // Global login
@@ -163,7 +163,7 @@ namespace Hestia.DevicesScreen
                 catch (ServerInteractionException ex)
                 {
                     Console.WriteLine("Exception while removing device. (Bug in server: exception is always thrown)");
-                    Console.Out.WriteLine(ex);
+                    Console.Out.WriteLine(ex.ToString());
                 }
             }
             // Remove device from list that is shown in the TableView

--- a/Hestia/Hestia/frontend/DevicesScreen/UITableViewControllerDevicesMain.cs
+++ b/Hestia/Hestia/frontend/DevicesScreen/UITableViewControllerDevicesMain.cs
@@ -88,7 +88,7 @@ namespace Hestia.DevicesScreen
         void HandleException(TableSourceDevicesMain source, ServerInteractionException ex)
         {
             Console.WriteLine("Exception while getting devices from local server");
-            Console.WriteLine(ex);
+            Console.WriteLine(ex.ToString());
             WarningMessage.Display("Could not refresh devices", "Exception while getting devices from local server", this);
             source.serverDevices = new List<List<Device>>();
             TableView.ReloadData();
@@ -280,7 +280,7 @@ namespace Hestia.DevicesScreen
                     catch (ServerInteractionException ex)
                     {
                         Console.WriteLine("Exception while changing activator state");
-                        Console.WriteLine(ex);
+                        Console.WriteLine(ex.ToString());
                     }
                     return;
                 }

--- a/Hestia/Hestia/frontend/EntryScreen/UIViewControllerLocalGlobal.cs
+++ b/Hestia/Hestia/frontend/EntryScreen/UIViewControllerLocalGlobal.cs
@@ -171,7 +171,7 @@ namespace Hestia
             catch (ServerInteractionException ex)
             {
                 Console.WriteLine("Exception while posting user. User possibly already exists.");
-                Console.WriteLine(ex.StackTrace);
+                Console.WriteLine(ex.ToString());
             }
             Globals.Auth0Servers = new List<HestiaServer>();
             try
@@ -183,7 +183,7 @@ namespace Hestia
             catch(ServerInteractionException ex)
             {
                 Console.WriteLine("Exception while getting servers");
-                Console.WriteLine(ex.StackTrace);
+                Console.WriteLine(ex.ToString());
                 WarningMessage.Display("Exception whle getting server", "Could not get the server information about local server from Auth0 server.", this);
             }
             Console.WriteLine("To Server Select Global");

--- a/Hestia/Hestia/frontend/Local/UITableViewControllerServerConnect.cs
+++ b/Hestia/Hestia/frontend/Local/UITableViewControllerServerConnect.cs
@@ -101,9 +101,9 @@ namespace Hestia.DevicesScreen
                 string address = strings.defaultPrefix + newIP.Text + ":" + int.Parse(strings.defaultPort);
                 validIp = PingServer.Check(address);
             }
-            catch (Exception exception)
+            catch (Exception ex)
             {
-                Console.WriteLine(exception.StackTrace);
+                Console.WriteLine(ex.ToString());
                 WarningMessage.Display("Could not connect to server", "Invalid server information", this);
                 connectButton.Selected = false;
                 return false;


### PR DESCRIPTION
When printing exceptions the `ToString` method is the preferred way of doing it, because it returns all important information. Before we often only printed only the stack trace which is not enough. "The default implementation of ToString obtains the name of the class that threw the current exception, the message, the result of calling ToString on the inner exception, and the result of calling Environment.StackTrace. If any of these members is null, its value is not included in the returned string."