### PR TITLE
Convert port to string

### DIFF
--- a/Hestia/Hestia/backend/HestiaWebServerInteractor.cs
+++ b/Hestia/Hestia/backend/HestiaWebServerInteractor.cs
@@ -56,7 +56,7 @@ namespace Hestia.backend
             {
                 { "server_name", name },
                 { "server_address", address },
-                { "server_port", port }
+                { "server_port", port.ToString() }
             };            
             string endpoint = strings.serversPath;
             networkHandler.Post(payload, endpoint);


### PR DESCRIPTION
Minor bug fix. The hestia web server expects a string, so we should convert it.